### PR TITLE
CIの失敗に伴う対応

### DIFF
--- a/src/main/java/nablarch/core/beans/BeanUtil.java
+++ b/src/main/java/nablarch/core/beans/BeanUtil.java
@@ -527,7 +527,10 @@ public final class BeanUtil {
      * @throws IllegalArgumentException 引数の{@code bean}がレコードの場合
      */
     public static void setProperty(final Object bean, final String propertyName, final Object propertyValue) {
-        setProperty(bean, propertyName, new HashMap<>(){{put(propertyName, propertyValue);}}, CopyOptions.empty());
+        Map<String, Object> parameterMap = new HashMap<>(){{
+            put(propertyName, propertyValue);
+        }};
+        setProperty(bean, propertyName, parameterMap, CopyOptions.empty());
     }
 
     /**

--- a/src/main/java/nablarch/core/beans/BeanUtil.java
+++ b/src/main/java/nablarch/core/beans/BeanUtil.java
@@ -527,7 +527,7 @@ public final class BeanUtil {
      * @throws IllegalArgumentException 引数の{@code bean}がレコードの場合
      */
     public static void setProperty(final Object bean, final String propertyName, final Object propertyValue) {
-        setProperty(bean, propertyName, Map.of(propertyName, propertyValue), CopyOptions.empty());
+        setProperty(bean, propertyName, new HashMap<>(){{put(propertyName, propertyValue);}}, CopyOptions.empty());
     }
 
     /**
@@ -828,7 +828,7 @@ public final class BeanUtil {
      */
     private static Map<String, ?> createPropertyMap(Class<?> beanClass, Map<String, ?> map, CopyOptions copyOptions) {
         if (map == null) {
-            return Map.of();
+            return Collections.emptyMap();
         }
 
         Map<String, Object> propertyMap = new HashMap<>();

--- a/src/main/java/nablarch/core/beans/BeanUtil.java
+++ b/src/main/java/nablarch/core/beans/BeanUtil.java
@@ -722,10 +722,12 @@ public final class BeanUtil {
                 if (hasConverter(beanClass, propertyName, mergedCopyOptions)) {
                     args[i] = createPropertyValue(beanClass, propertyName, val, mergedCopyOptions);
                 } else {
-                    if (parameterTypes[i].isRecord()) {
-                        args[i] = createRecord(parameterTypes[i], val, CopyOptions.empty());
-                    } else {
-                        args[i] = copyInner(val, createInstance(parameterTypes[i]), CopyOptions.empty());
+                    if (val != null) {
+                        if (parameterTypes[i].isRecord()) {
+                            args[i] = createRecord(parameterTypes[i], val, CopyOptions.empty());
+                        } else {
+                            args[i] = copyInner(val, createInstance(parameterTypes[i]), CopyOptions.empty());
+                        }
                     }
                 }
             } catch (BeansException bex) {

--- a/src/test/java/nablarch/core/beans/BeanUtilForNullPropertyTest.java
+++ b/src/test/java/nablarch/core/beans/BeanUtilForNullPropertyTest.java
@@ -1,0 +1,137 @@
+package nablarch.core.beans;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Nablarch 6における、BeanUtilでのnullプロパティの挙動を確認するテスト。
+ */
+@SuppressWarnings("NonAsciiCharacters")
+public class BeanUtilForNullPropertyTest {
+
+    private static class SrcBean {
+        private String name;
+        public String getName() {
+            return name;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    private static class DestBean {
+        private String name;
+        public String getName() {
+            return name;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void setProperty_propertyNameがnullの場合は実行時例外が送出されること() {
+        IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () ->
+                BeanUtil.setProperty(new DestBean(), null, "value"));
+        assertThat(result.getMessage(), is("expression is null or blank."));
+    }
+
+    @Test
+    public void setProperty_propertyValueがnullの場合は成功すること() {
+        DestBean dest = new DestBean();
+        dest.setName("value");
+
+        BeanUtil.setProperty(dest, "name", null);
+        assertThat(dest.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をMapとするcopy_keyがnullの場合は実行時例外が送出されること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put(null, "value");}};
+
+        IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () ->
+                BeanUtil.copy(DestBean.class, new DestBean(), srcMap, CopyOptions.empty()));
+        assertThat(result.getMessage(), is("expression is null or blank."));
+    }
+
+    @Test
+    public void 移送元をMapとするcopy_valueがnullの場合は成功すること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("name", null);}};
+        DestBean dest = new DestBean();
+        dest.setName("value");
+
+        BeanUtil.copy(DestBean.class, dest, srcMap, CopyOptions.empty());
+        assertThat(dest.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をBeanとするcopy_valueがnullの場合は成功すること() {
+        SrcBean src = new SrcBean();
+        src.setName(null);
+        DestBean dest = new DestBean();
+        dest.setName("value");
+
+        BeanUtil.copy(src, dest, CopyOptions.empty());
+        assertThat(dest.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyIncludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("name", "value");}};
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyIncludes(DestBean.class, srcMap, (String[]) null));
+
+        BeansException beansException = assertThrows(BeansException.class, () ->
+                BeanUtil.createAndCopyIncludes(DestBean.class, srcMap, (String) null));
+        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyExcludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("name", "value");}};
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyExcludes(DestBean.class, srcMap, (String[]) null));
+
+        BeansException beansException = assertThrows(BeansException.class, () ->
+                BeanUtil.createAndCopyExcludes(DestBean.class, srcMap, (String) null));
+        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyIncludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+        SrcBean src = new SrcBean();
+        src.setName("value");
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyIncludes(DestBean.class, src, (String[]) null));
+
+        BeansException beansException = assertThrows(BeansException.class, () ->
+                BeanUtil.createAndCopyIncludes(DestBean.class, src, (String) null));
+        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyExcludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+        SrcBean src = new SrcBean();
+        src.setName("value");
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyExcludes(DestBean.class, src, (String[]) null));
+
+        BeansException beansException = assertThrows(BeansException.class, () ->
+                BeanUtil.createAndCopyExcludes(DestBean.class, src, (String) null));
+        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+
+    }
+}

--- a/src/test/java/nablarch/core/beans/BeanUtilForNullPropertyTest.java
+++ b/src/test/java/nablarch/core/beans/BeanUtilForNullPropertyTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertThrows;
 @SuppressWarnings("NonAsciiCharacters")
 public class BeanUtilForNullPropertyTest {
 
-    private static class SrcBean {
+    public static class SrcBean {
         private String name;
         public String getName() {
             return name;
@@ -25,7 +25,37 @@ public class BeanUtilForNullPropertyTest {
         }
     }
 
-    private static class DestBean {
+    public static class DestBean {
+        private String name;
+        public String getName() {
+            return name;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class SrcParentBean {
+        private ChildBean childBean;
+        public ChildBean getChildBean() {
+            return childBean;
+        }
+        public void setChildBean(ChildBean childBean) {
+            this.childBean = childBean;
+        }
+    }
+
+    public static class DestParentBean {
+        private ChildBean childBean;
+        public ChildBean getChildBean() {
+            return childBean;
+        }
+        public void setChildBean(ChildBean childBean) {
+            this.childBean = childBean;
+        }
+    }
+
+    public static class ChildBean {
         private String name;
         public String getName() {
             return name;
@@ -82,56 +112,107 @@ public class BeanUtilForNullPropertyTest {
     }
 
     @Test
-    public void 移送元をMapとするcreateAndCopyIncludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+    public void 移送元をBeanとするcopy_コピー元beanがnullの場合はNPEが送出されること() {
+        DestBean dest = new DestBean();
+        dest.setName("value");
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.copy(null, dest, CopyOptions.empty()));
+    }
+
+    @Test
+    public void 移送元をBeanとするcopy_コピー先beanがnullの場合はNPEが送出されること() {
+        SrcBean src = new SrcBean();
+        src.setName("value");
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.copy(src, null, CopyOptions.empty()));
+    }
+
+    @Test
+    public void 移送元をBeanとするcopy_コピー元beanの子Beanがnullの場合はコピーされないこと() {
+        SrcParentBean src = new SrcParentBean();
+        src.setChildBean(null);
+        DestParentBean dest = new DestParentBean();
+        dest.setChildBean(new ChildBean());
+
+        BeanUtil.copy(src, dest, CopyOptions.empty());
+        // CopyOptions.empty().isExcludesNull() == false なので、nullのプロパティもコピーされるはずだが、Nablarch6時点ではではコピーされない。
+        assertThat(dest.getChildBean(), instanceOf(ChildBean.class));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyIncludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
         Map<String, Object> srcMap = new HashMap<>(){{put("name", "value");}};
 
         assertThrows(NullPointerException.class, () ->
                 BeanUtil.createAndCopyIncludes(DestBean.class, srcMap, (String[]) null));
 
-        BeansException beansException = assertThrows(BeansException.class, () ->
-                BeanUtil.createAndCopyIncludes(DestBean.class, srcMap, (String) null));
-        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
-
     }
 
     @Test
-    public void 移送元をMapとするcreateAndCopyExcludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+    public void 移送元をMapとするcreateAndCopyIncludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("name", "value");}};
+
+        DestBean dest = BeanUtil.createAndCopyIncludes(DestBean.class, srcMap, (String) null);
+        assertThat(dest.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyExcludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
         Map<String, Object> srcMap = new HashMap<>(){{put("name", "value");}};
 
         assertThrows(NullPointerException.class, () ->
                 BeanUtil.createAndCopyExcludes(DestBean.class, srcMap, (String[]) null));
 
-        BeansException beansException = assertThrows(BeansException.class, () ->
-                BeanUtil.createAndCopyExcludes(DestBean.class, srcMap, (String) null));
-        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyExcludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("name", "value");}};
+
+        DestBean dest = BeanUtil.createAndCopyExcludes(DestBean.class, srcMap, (String) null);
+        assertThat(dest.getName(), is("value"));
 
     }
 
     @Test
-    public void 移送元をBeanとするcreateAndCopyIncludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+    public void 移送元をBeanとするcreateAndCopyIncludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
         SrcBean src = new SrcBean();
         src.setName("value");
 
         assertThrows(NullPointerException.class, () ->
                 BeanUtil.createAndCopyIncludes(DestBean.class, src, (String[]) null));
 
-        BeansException beansException = assertThrows(BeansException.class, () ->
-                BeanUtil.createAndCopyIncludes(DestBean.class, src, (String) null));
-        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyIncludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        SrcBean src = new SrcBean();
+        src.setName("value");
+
+        DestBean dest = BeanUtil.createAndCopyIncludes(DestBean.class, src, (String) null);
+        assertThat(dest.getName(), is(nullValue()));
 
     }
 
     @Test
-    public void 移送元をBeanとするcreateAndCopyExcludes_プロパティの指定がnullの場合は実行時例外が送出されること() {
+    public void 移送元をBeanとするcreateAndCopyExcludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
         SrcBean src = new SrcBean();
         src.setName("value");
 
         assertThrows(NullPointerException.class, () ->
                 BeanUtil.createAndCopyExcludes(DestBean.class, src, (String[]) null));
 
-        BeansException beansException = assertThrows(BeansException.class, () ->
-                BeanUtil.createAndCopyExcludes(DestBean.class, src, (String) null));
-        assertThat(beansException.getCause(), instanceOf(NoSuchMethodException.class));
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyExcludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        SrcBean src = new SrcBean();
+        src.setName("value");
+
+        DestBean dest = BeanUtil.createAndCopyExcludes(DestBean.class, src, (String) null);
+        assertThat(dest.getName(), is("value"));
 
     }
 }

--- a/src/test/java/nablarch/core/beans/BeanUtilForRecordTest.java
+++ b/src/test/java/nablarch/core/beans/BeanUtilForRecordTest.java
@@ -3,7 +3,6 @@ package nablarch.core.beans;
 import nablarch.core.repository.SystemRepository;
 import nablarch.test.support.log.app.OnMemoryLogWriter;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -1565,6 +1564,111 @@ public class BeanUtilForRecordTest {
         assertThat(destRecord.foo(), is(sameInstance(date)));
         assertThat(destRecord.bar(), is(sameInstance(sqlDate)));
         assertThat(destRecord.baz(), is(sameInstance(timestamp)));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopy_keyがnullの場合は実行時例外が送出されること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put(null, 10);}};
+
+        IllegalArgumentException result = assertThrows(IllegalArgumentException.class, () ->
+                BeanUtil.createAndCopy(TestRecord.class, srcMap, CopyOptions.empty()));
+        assertThat(result.getMessage(), is("expression is null or blank."));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopy_valueがnullの場合は成功すること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("sample", null);}};
+        TestRecord dest = BeanUtil.createAndCopy(TestRecord.class, srcMap, CopyOptions.empty());
+        assertThat(dest.sample(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopy_移送元の各プロパティがnullの場合は成功すること() {
+        SourceBean src = new SourceBean();
+
+        TestRecord dest = BeanUtil.createAndCopy(TestRecord.class, src, CopyOptions.empty());
+        assertThat(dest.sample(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopy_コピー元beanがnullの場合はNPEが送出されること() {
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopy(TestRecord.class, (SourceBean) null, CopyOptions.empty()));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyIncludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("sample", 10);}};
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyIncludes(TestRecord.class, srcMap, (String[]) null));
+
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyIncludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("sample", 10);}};
+
+        TestRecord dest = BeanUtil.createAndCopyIncludes(TestRecord.class, srcMap, (String) null);
+        assertThat(dest.sample(), is(nullValue()));
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyExcludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("sample", 10);}};
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyExcludes(TestRecord.class, srcMap, (String[]) null));
+
+    }
+
+    @Test
+    public void 移送元をMapとするcreateAndCopyExcludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        Map<String, Object> srcMap = new HashMap<>(){{put("sample", 10);}};
+
+        TestRecord dest = BeanUtil.createAndCopyExcludes(TestRecord.class, srcMap, (String) null);
+        assertThat(dest.sample(), is(10));
+
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyIncludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
+        SourceBean src = new SourceBean();
+        src.setSample(10);
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyIncludes(TestRecord.class, src, (String[]) null));
+
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyIncludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        SourceBean src = new SourceBean();
+        src.setSample(10);
+
+        TestRecord dest = BeanUtil.createAndCopyIncludes(TestRecord.class, src, (String) null);
+        assertThat(dest.sample(), is(nullValue()));
+
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyExcludes_プロパティの指定がStringの配列にキャストされたnullの場合は実行時例外が送出されること() {
+        SourceBean src = new SourceBean();
+        src.setSample(10);
+
+        assertThrows(NullPointerException.class, () ->
+                BeanUtil.createAndCopyExcludes(TestRecord.class, src, (String[]) null));
+
+    }
+
+    @Test
+    public void 移送元をBeanとするcreateAndCopyExcludes_プロパティの指定がStringにキャストされたnullの場合は成功すること() {
+        SourceBean src = new SourceBean();
+        src.setSample(10);
+
+        TestRecord dest = BeanUtil.createAndCopyExcludes(TestRecord.class, src, (String) null);
+        assertThat(dest.sample(), is(10));
+
     }
 
 }


### PR DESCRIPTION
* Nablarch6時点の機能について、メソッドにnullを渡した時の挙動を確認するテストを追加
* 新規に作成したレコード関連機能について、上記のテストの観点を踏まえテスト追加
* テストが成功するよう実装を修正
* CIで失敗したテストは、ローカル環境で成功することを確認済