### PR TITLE
ExtensionConverterを公開API化しました

### DIFF
--- a/src/main/java/nablarch/core/beans/ExtensionConverter.java
+++ b/src/main/java/nablarch/core/beans/ExtensionConverter.java
@@ -1,5 +1,7 @@
 package nablarch.core.beans;
 
+import nablarch.core.util.annotation.Published;
+
 /**
  * 拡張の型変換インタフェース。
  * <p>
@@ -8,6 +10,7 @@ package nablarch.core.beans;
  * @param <T> 型変換後に返す型
  * @author siosio
  */
+@Published(tag = "architect")
 public interface ExtensionConverter<T> {
 
     /**


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/bean_util.html#utility-conversion-add-rule)には`ExtensionConverter`の実装例が記載されているにもかかわらず、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。