### PR TITLE
test: カバレッジが不足していたためテストを追加

### DIFF
--- a/src/test/java/nablarch/core/beans/ConversionUtilTest.java
+++ b/src/test/java/nablarch/core/beans/ConversionUtilTest.java
@@ -360,6 +360,102 @@ public class ConversionUtilTest {
     }
 
     @Test
+    public void testConvertLocalDate() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.FEBRUARY, 13, 0, 0, 0);
+        cal.clear(Calendar.MILLISECOND);
+        LocalDate localDate = LocalDate.of(2024, 2, 13);
+
+        // String
+        assertEquals(localDate, ConversionUtil.convert(LocalDate.class, "20240213"));
+
+        // String[]
+        assertEquals(localDate, ConversionUtil.convert(LocalDate.class, new String[]{"20240213"}));
+
+        // String[] {null}
+        assertNull(ConversionUtil.convert(LocalDate.class, new String[] {null}));
+
+        // Date
+        assertEquals(localDate, ConversionUtil.convert(LocalDate.class, cal.getTime()));
+
+
+        // Calendar
+        assertEquals(localDate, ConversionUtil.convert(LocalDate.class, cal));
+
+        // null
+        assertNull(ConversionUtil.convert(LocalDate.class, null));
+
+        // LocalDate
+        assertEquals(localDate, ConversionUtil.convert(LocalDate.class, LocalDate.of(2024, 2, 13)));
+
+        // LocalDateTime
+        assertEquals(localDate, ConversionUtil.convert(LocalDate.class, LocalDateTime.of(2024, 2, 13, 0, 0, 0)));
+
+        try {
+            ConversionUtil.convert(LocalDate.class, new String[] {"20240213", "20240212"});
+            fail();
+        } catch (Throwable e) {
+            assertTrue(e instanceof ConversionException);
+        }
+
+        // unsupported type
+        try {
+            ConversionUtil.convert(LocalDate.class, System.currentTimeMillis());
+            fail();
+        } catch (Throwable e) {
+            assertTrue(e instanceof ConversionException);
+        }
+    }
+
+    @Test
+    public void testConvertLocalDateTime() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.FEBRUARY, 13, 10, 22, 30);
+        cal.clear(Calendar.MILLISECOND);
+        LocalDateTime localDateTime =  LocalDateTime.of(2024, 2, 13, 10, 22, 30);
+
+        // String
+        assertEquals(localDateTime, ConversionUtil.convert(LocalDateTime.class, "2024-02-13T10:22:30.000Z"));
+
+        // String[]
+        assertEquals(localDateTime, ConversionUtil.convert(LocalDateTime.class, new String[]{"2024-02-13T10:22:30.000Z"}));
+
+        // String[] {null}
+        assertNull(ConversionUtil.convert(LocalDateTime.class, new String[] {null}));
+
+        // Date
+        assertEquals(localDateTime, ConversionUtil.convert(LocalDateTime.class, cal.getTime()));
+
+
+        // Calendar
+        assertEquals(localDateTime, ConversionUtil.convert(LocalDateTime.class, cal));
+
+        // null
+        assertNull(ConversionUtil.convert(LocalDateTime.class, null));
+
+        // LocalDate
+        assertEquals(LocalDateTime.of(2024, 2, 13, 0, 0), ConversionUtil.convert(LocalDateTime.class, LocalDate.of(2024, 2, 13)));
+
+        // LocalDateTime
+        assertEquals(localDateTime, ConversionUtil.convert(LocalDateTime.class, localDateTime));
+
+        try {
+            ConversionUtil.convert(LocalDateTime.class, new String[] {"20240213", "20240212"});
+            fail();
+        } catch (Throwable e) {
+            assertTrue(e instanceof ConversionException);
+        }
+
+        // unsupported type
+        try {
+            ConversionUtil.convert(LocalDateTime.class, System.currentTimeMillis());
+            fail();
+        } catch (Throwable e) {
+            assertTrue(e instanceof ConversionException);
+        }
+    }
+
+    @Test
     public void testConvertLong() {
 
         // Number

--- a/src/test/java/nablarch/core/beans/CopyOptionsTest.java
+++ b/src/test/java/nablarch/core/beans/CopyOptionsTest.java
@@ -130,22 +130,22 @@ public class CopyOptionsTest {
                 .build();
 
         assertThat(sut.hasTypedConverter(LocalDate.class), is(true));
-        assertThat((LocalDate) sut.convertByType(LocalDate.class, date("2018-02-14 00:00:00")), is(LocalDate.of(2018, 2, 14)));
+        assertThat(sut.convertByType(LocalDate.class, date("2018-02-14 00:00:00")), is(LocalDate.of(2018, 2, 14)));
 
         assertThat(sut.hasTypedConverter(LocalDateTime.class), is(true));
-        assertThat((LocalDateTime) sut.convertByType(LocalDateTime.class, date("2018-02-14 00:00:00")), is(LocalDateTime.of(2018, 2, 14, 0, 0)));
+        assertThat(sut.convertByType(LocalDateTime.class, date("2018-02-14 00:00:00")), is(LocalDateTime.of(2018, 2, 14, 0, 0)));
 
         assertThat(sut.hasTypedConverter(java.util.Date.class), is(true));
-        assertThat((java.util.Date) sut.convertByType(java.util.Date.class, date("2018-02-14 00:00:00")), is(date("2018-02-14 00:00:00")));
+        assertThat(sut.convertByType(java.util.Date.class, date("2018-02-14 00:00:00")), is(date("2018-02-14 00:00:00")));
 
         assertThat(sut.hasTypedConverter(java.sql.Date.class), is(true));
-        assertThat((java.sql.Date) sut.convertByType(java.sql.Date.class, date("2018-02-14 00:00:00")), is(date("2018-02-14 00:00:00")));
+        assertThat(sut.convertByType(java.sql.Date.class, date("2018-02-14 00:00:00")), is(date("2018-02-14 00:00:00")));
 
         assertThat(sut.hasTypedConverter(Timestamp.class), is(true));
-        assertThat((Timestamp) sut.convertByType(Timestamp.class, date("2018-02-14 00:00:00")), is(Timestamp.valueOf("2018-02-14 00:00:00")));
+        assertThat(sut.convertByType(Timestamp.class, date("2018-02-14 00:00:00")), is(Timestamp.valueOf("2018-02-14 00:00:00")));
 
         assertThat(sut.hasTypedConverter(String.class), is(true));
-        assertThat((String) sut.convertByType(String.class, date("2018-02-14 00:00:00")), is("2018/02/14"));
+        assertThat(sut.convertByType(String.class, date("2018-02-14 00:00:00")), is("2018/02/14"));
 
         assertThat(sut.hasTypedConverter(Object.class), is(false));
 
@@ -159,28 +159,28 @@ public class CopyOptionsTest {
                 .build();
 
         assertThat(sut.hasTypedConverter(short.class), is(true));
-        assertThat((short) sut.convertByType(Short.class, 32500), is((short) 32500));
+        assertThat(sut.convertByType(Short.class, 32500), is((short) 32500));
 
         assertThat(sut.hasTypedConverter(int.class), is(true));
-        assertThat((int) sut.convertByType(int.class, 2147483647), is(2147483647));
+        assertThat(sut.convertByType(int.class, 2147483647), is(2147483647));
 
         assertThat(sut.hasTypedConverter(long.class), is(true));
-        assertThat((long) sut.convertByType(long.class, 32500), is(32500L));
+        assertThat(sut.convertByType(long.class, 32500), is(32500L));
 
         assertThat(sut.hasTypedConverter(Short.class), is(true));
-        assertThat((Short) sut.convertByType(Short.class, 32500), is(Short.valueOf("32500")));
+        assertThat(sut.convertByType(Short.class, 32500), is(Short.valueOf("32500")));
 
         assertThat(sut.hasTypedConverter(Integer.class), is(true));
-        assertThat((Integer) sut.convertByType(Integer.class, 32500), is(Integer.valueOf("32500")));
+        assertThat(sut.convertByType(Integer.class, 32500), is(Integer.valueOf("32500")));
 
         assertThat(sut.hasTypedConverter(Long.class), is(true));
-        assertThat((Long) sut.convertByType(Long.class, 32500), is(Long.valueOf("32500")));
+        assertThat(sut.convertByType(Long.class, 32500), is(Long.valueOf("32500")));
 
         assertThat(sut.hasTypedConverter(BigDecimal.class), is(true));
-        assertThat((BigDecimal) sut.convertByType(BigDecimal.class, 32500), is(BigDecimal.valueOf(32500L)));
+        assertThat(sut.convertByType(BigDecimal.class, 32500), is(BigDecimal.valueOf(32500L)));
 
         assertThat(sut.hasTypedConverter(String.class), is(true));
-        assertThat((String) sut.convertByType(String.class, 1234567890), is("1,234,567,890"));
+        assertThat(sut.convertByType(String.class, 1234567890), is("1,234,567,890"));
 
         assertThat(sut.hasTypedConverter(Object.class), is(false));
     }

--- a/src/test/java/nablarch/core/beans/sample/CustomConversionManager.java
+++ b/src/test/java/nablarch/core/beans/sample/CustomConversionManager.java
@@ -3,6 +3,8 @@ package nablarch.core.beans.sample;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -16,6 +18,8 @@ import nablarch.core.beans.converter.BigDecimalConverter;
 import nablarch.core.beans.converter.BooleanConverter;
 import nablarch.core.beans.converter.DateConverter;
 import nablarch.core.beans.converter.IntegerConverter;
+import nablarch.core.beans.converter.LocalDateConverter;
+import nablarch.core.beans.converter.LocalDateTimeConverter;
 import nablarch.core.beans.converter.LongConverter;
 import nablarch.core.beans.converter.ObjectArrayConverter;
 import nablarch.core.beans.converter.ShortConverter;
@@ -52,6 +56,8 @@ public class CustomConversionManager implements ConversionManager {
         converterMap.put(Date.class, new DateConverter());
         converterMap.put(java.sql.Date.class, new SqlDateConverter());
         converterMap.put(Timestamp.class, new SqlTimestampConverter());
+        converterMap.put(LocalDate.class, new LocalDateConverter());
+        converterMap.put(LocalDateTime.class, new LocalDateTimeConverter());
 
         // PJ固有のコンバータ
         converterMap.put(BigInteger.class, new CustomConverter());


### PR DESCRIPTION
- SonarQubeでLocalDateConverterとLocalDateTimeConverterのカバレッジが不足していたためテストを追加しました。（以下二つの理由からカバレッジが満たされている型のテストも追加しています。）
  - 他のコンバータもConversionUtilTestではConverteTestと被っている型のテストも重ねて行っていたこと
  - テストケースの整理は時間がかかること 

- SonarQubeでMajor指摘に対応しました。
  - 指摘内容：Boxed value is unboxed and then immediately reboxed in nablarch.core.beans.CopyOptionsTest.numberPatterns()