### PR TITLE
OffsetDateTimeのサポートを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <!-- テスト時にタイムゾーンを固定 -->
+            <user.timezone>Asia/Tokyo</user.timezone>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/nablarch/core/beans/BasicConversionManager.java
+++ b/src/main/java/nablarch/core/beans/BasicConversionManager.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -22,6 +23,7 @@ import nablarch.core.beans.converter.LocalDateConverter;
 import nablarch.core.beans.converter.LocalDateTimeConverter;
 import nablarch.core.beans.converter.LongConverter;
 import nablarch.core.beans.converter.ObjectArrayConverter;
+import nablarch.core.beans.converter.OffsetDateTimeConverter;
 import nablarch.core.beans.converter.SetExtensionConverter;
 import nablarch.core.beans.converter.ShortConverter;
 import nablarch.core.beans.converter.SqlDateConverter;
@@ -66,6 +68,7 @@ public class BasicConversionManager implements ConversionManager {
         convertMap.put(Timestamp.class, new SqlTimestampConverter());
         convertMap.put(LocalDate.class, new LocalDateConverter());
         convertMap.put(LocalDateTime.class, new LocalDateTimeConverter());
+        convertMap.put(OffsetDateTime.class, new OffsetDateTimeConverter());
         convertMap.put(byte[].class, new BytesConverter());
         converters = Collections.unmodifiableMap(convertMap);
 
@@ -100,6 +103,7 @@ public class BasicConversionManager implements ConversionManager {
                 converters);
         convertMap.put(LocalDate.class, new LocalDateConverter(patterns));
         convertMap.put(LocalDateTime.class, new LocalDateTimeConverter(patterns));
+        convertMap.put(OffsetDateTime.class, new OffsetDateTimeConverter(patterns));
         convertMap.put(Date.class, new DateConverter(patterns));
         convertMap.put(java.sql.Date.class, new SqlDateConverter(patterns));
         convertMap.put(Timestamp.class, new SqlTimestampConverter(patterns));

--- a/src/main/java/nablarch/core/beans/CopyOptions.java
+++ b/src/main/java/nablarch/core/beans/CopyOptions.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,7 +18,12 @@ import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 
-import nablarch.core.beans.converter.*;
+import nablarch.core.beans.converter.BigDecimalConverter;
+import nablarch.core.beans.converter.IntegerConverter;
+import nablarch.core.beans.converter.LongConverter;
+import nablarch.core.beans.converter.ShortConverter;
+import nablarch.core.beans.converter.SqlTimestampConverter;
+import nablarch.core.beans.converter.StringConverter;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.annotation.Published;
 
@@ -761,6 +767,7 @@ public final class CopyOptions {
             converters.put(String.class, new StringConverter(patterns.get(0), null));
             converters.put(LocalDate.class, new LocalDateConverter(patterns));
             converters.put(LocalDateTime.class, new LocalDateTimeConverter(patterns));
+            converters.put(OffsetDateTime.class, new OffsetDateTimeConverter(patterns));
             converters.put(java.util.Date.class, new DateConverter(patterns));
             converters.put(java.sql.Date.class, new SqlDateConverter(patterns));
             converters.put(Timestamp.class, new SqlTimestampConverter(patterns));

--- a/src/main/java/nablarch/core/beans/CopyOptions.java
+++ b/src/main/java/nablarch/core/beans/CopyOptions.java
@@ -19,9 +19,14 @@ import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 
 import nablarch.core.beans.converter.BigDecimalConverter;
+import nablarch.core.beans.converter.DateConverter;
 import nablarch.core.beans.converter.IntegerConverter;
+import nablarch.core.beans.converter.LocalDateConverter;
+import nablarch.core.beans.converter.LocalDateTimeConverter;
 import nablarch.core.beans.converter.LongConverter;
+import nablarch.core.beans.converter.OffsetDateTimeConverter;
 import nablarch.core.beans.converter.ShortConverter;
+import nablarch.core.beans.converter.SqlDateConverter;
 import nablarch.core.beans.converter.SqlTimestampConverter;
 import nablarch.core.beans.converter.StringConverter;
 import nablarch.core.repository.SystemRepository;

--- a/src/main/java/nablarch/core/beans/converter/BasicDateTimeConverterConfiguration.java
+++ b/src/main/java/nablarch/core/beans/converter/BasicDateTimeConverterConfiguration.java
@@ -1,9 +1,15 @@
 package nablarch.core.beans.converter;
 
+import java.time.ZoneId;
+
 /**
  * {@link DateTimeConverterConfiguration}のデフォルト実装クラス
  *
  * @author TIS
  */
 public class BasicDateTimeConverterConfiguration implements DateTimeConverterConfiguration {
+    @Override
+    public ZoneId getSystemZoneId() {
+        return ZoneId.systemDefault();
+    }
 }

--- a/src/main/java/nablarch/core/beans/converter/BasicDateTimeConverterConfiguration.java
+++ b/src/main/java/nablarch/core/beans/converter/BasicDateTimeConverterConfiguration.java
@@ -1,27 +1,9 @@
 package nablarch.core.beans.converter;
 
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-
 /**
  * {@link DateTimeConverterConfiguration}のデフォルト実装クラス
  *
  * @author TIS
  */
 public class BasicDateTimeConverterConfiguration implements DateTimeConverterConfiguration {
-
-    @Override
-    public DateTimeFormatter getDateFormatter() {
-        return DateTimeFormatter.BASIC_ISO_DATE;
-    }
-
-    @Override
-    public DateTimeFormatter getDateTimeFormatter() {
-        return DateTimeFormatter.ISO_INSTANT;
-    }
-
-    @Override
-    public ZoneId getSystemZoneId() {
-        return ZoneId.systemDefault();
-    }
 }

--- a/src/main/java/nablarch/core/beans/converter/DateConverter.java
+++ b/src/main/java/nablarch/core/beans/converter/DateConverter.java
@@ -4,6 +4,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -76,6 +77,8 @@ public class DateConverter implements Converter<Date> {
             return DateTimeConverterUtil.getDate(localDateTime);
         } else if (value instanceof LocalDate localDate) {
             return DateTimeConverterUtil.getDate(localDate);
+        } else if (value instanceof OffsetDateTime offsetDateTime) {
+            return DateTimeConverterUtil.getDate(offsetDateTime);
         } else {
             throw new ConversionException(Date.class, value);
         }

--- a/src/main/java/nablarch/core/beans/converter/DateTimeConverterConfiguration.java
+++ b/src/main/java/nablarch/core/beans/converter/DateTimeConverterConfiguration.java
@@ -12,20 +12,23 @@ import java.time.format.DateTimeFormatter;
  */
 @Published(tag = "architect")
 public interface DateTimeConverterConfiguration {
-
     /**
      * 日付向けのフォーマッタ
      *
      * @return 日付向けの{@code java.time.format.DateTimeFormatter}のインスタンス
      */
-    DateTimeFormatter getDateFormatter();
+    default DateTimeFormatter getDateFormatter() {
+        return DateTimeFormatter.BASIC_ISO_DATE;
+    }
 
     /**
      * 日時向けのフォーマッタ
      *
      * @return 日時向けの{@code java.time.format.DateTimeFormatter}のインスタンス
      */
-    DateTimeFormatter getDateTimeFormatter();
+    default DateTimeFormatter getDateTimeFormatter() {
+        return DateTimeFormatter.ISO_INSTANT;
+    }
 
     /**
      * オフセット付き日時向けのフォーマッタ
@@ -41,5 +44,7 @@ public interface DateTimeConverterConfiguration {
      *
      * @return システムが依存するで管理している{@code java.time.ZoneId}
      */
-    ZoneId getSystemZoneId();
+    default ZoneId getSystemZoneId() {
+        return ZoneId.systemDefault();
+    }
 }

--- a/src/main/java/nablarch/core/beans/converter/DateTimeConverterConfiguration.java
+++ b/src/main/java/nablarch/core/beans/converter/DateTimeConverterConfiguration.java
@@ -44,7 +44,5 @@ public interface DateTimeConverterConfiguration {
      *
      * @return システムが依存するで管理している{@code java.time.ZoneId}
      */
-    default ZoneId getSystemZoneId() {
-        return ZoneId.systemDefault();
-    }
+    ZoneId getSystemZoneId();
 }

--- a/src/main/java/nablarch/core/beans/converter/DateTimeConverterConfiguration.java
+++ b/src/main/java/nablarch/core/beans/converter/DateTimeConverterConfiguration.java
@@ -28,6 +28,15 @@ public interface DateTimeConverterConfiguration {
     DateTimeFormatter getDateTimeFormatter();
 
     /**
+     * オフセット付き日時向けのフォーマッタ
+     *
+     * @return オフセット付き日時向けの{@code java.time.format.DateTimeFormatter}のインスタンス
+     */
+    default DateTimeFormatter getOffsetDateTimeFormatter() {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+    }
+
+    /**
      * システムが依存する{@code java.time.ZoneId}を取得する
      *
      * @return システムが依存するで管理している{@code java.time.ZoneId}

--- a/src/main/java/nablarch/core/beans/converter/DateTimeConverterUtil.java
+++ b/src/main/java/nablarch/core/beans/converter/DateTimeConverterUtil.java
@@ -7,6 +7,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
@@ -99,6 +100,16 @@ public final class DateTimeConverterUtil {
     }
 
     /**
+     * {@code java.time.OffsetDateTime}のインスタンスを、{@code java.time.LocalDate}に変換する。
+     *
+     * @param dateTime 変換対象の{@code java.time.OffsetDateTime}のインスタンス
+     * @return 変換後の{@code java.time.LocalDate}のインスタンス
+     */
+    public static LocalDate getLocalDate(final OffsetDateTime dateTime) {
+        return dateTime.atZoneSameInstant(getDateTimeConverterConfiguration().getSystemZoneId()).toLocalDate();
+    }
+
+    /**
      * 日時文字列を{@link LocalDateTime}に変換する。
      *
      * @param date 変換対象の日時文字列
@@ -148,6 +159,76 @@ public final class DateTimeConverterUtil {
     }
 
     /**
+     * {@code java.time.OffsetDateTime}のインスタンスを、{@code java.time.LocalDateTime}に変換する。
+     *
+     * @param dateTime 変換対象の{@code java.time.OffsetDateTime}のインスタンス
+     * @return 変換後の{@code java.time.LocalDateTime}のインスタンス
+     */
+    public static LocalDateTime getLocalDateTime(final OffsetDateTime dateTime) {
+        return dateTime.atZoneSameInstant(getDateTimeConverterConfiguration().getSystemZoneId()).toLocalDateTime();
+    }
+
+    /**
+     * 日時文字列を{@link OffsetDateTime}に変換する。
+     *
+     * @param date 変換対象の日時文字列
+     * @return 変換後の値
+     */
+    public static OffsetDateTime getOffsetDateTime(String date) {
+        return OffsetDateTime.parse(date, getDateTimeConverterConfiguration().getOffsetDateTimeFormatter());
+    }
+
+    /**
+     * {@code java.util.Date}のインスタンスを、{@code java.time.OffsetDateTime}に変換する
+     *
+     * @param date 変換対象の{@code java.util.Date}のインスタンス
+     * @return 変換後の{@code java.time.OffsetDateTime}のインスタンス
+     */
+    public static OffsetDateTime getOffsetDateTime(Date date) {
+        return OffsetDateTime.ofInstant(date.toInstant(), getDateTimeConverterConfiguration().getSystemZoneId());
+    }
+
+    /**
+     * {@code java.sql.Date}のインスタンスを、{@code java.time.OffsetDateTime}に変換する
+     *
+     * @param date 変換対象の{@code java.sql.Date}のインスタンス
+     * @return 変換後の{@code java.time.OffsetDateTime}のインスタンス
+     */
+    public static OffsetDateTime getOffsetDateTimeAsSqlDate(java.sql.Date date) {
+        return date.toLocalDate().atStartOfDay(getDateTimeConverterConfiguration().getSystemZoneId()).toOffsetDateTime();
+    }
+
+    /**
+     * {@code java.util.Calendar}のインスタンスを、{@code java.time.OffsetDateTime}に変換する
+     *
+     * @param calendar 変換対象の{@code java.util.Calendar}のインスタンス
+     * @return 変換後の{@code java.time.OffsetDateTime}のインスタンス
+     */
+    public static OffsetDateTime getOffsetDateTime(Calendar calendar) {
+        return getOffsetDateTime(calendar.getTime());
+    }
+
+    /**
+     * {@code java.time.LocalDate}のインスタンスを、{@code java.time.OffsetDateTime}に変換する
+     *
+     * @param date 変換対象の{@code java.time.LocalDate}のインスタンス
+     * @return 変換後の{@code java.time.OffsetDateTime}のインスタンス
+     */
+    public static OffsetDateTime getOffsetDateTime(LocalDate date) {
+        return date.atStartOfDay(getDateTimeConverterConfiguration().getSystemZoneId()).toOffsetDateTime();
+    }
+
+    /**
+     * {@code java.time.LocalDateTime}のインスタンスを、{@code java.time.OffsetDateTime}に変換する
+     *
+     * @param dateTime 変換対象の{@code java.time.LocalDateTime}のインスタンス
+     * @return 変換後の{@code java.time.OffsetDateTime}のインスタンス
+     */
+    public static OffsetDateTime getOffsetDateTime(LocalDateTime dateTime) {
+        return dateTime.atZone(getDateTimeConverterConfiguration().getSystemZoneId()).toOffsetDateTime();
+    }
+
+    /**
      * {@code java.time.LocalDateTime}のインスタンスを{@code java.util.Date}に変換する
      *
      * @param dateTime 変換対象の{@code java.time.LocalDateTime}のインスタンス
@@ -170,6 +251,17 @@ public final class DateTimeConverterUtil {
     }
 
     /**
+     * {@code java.time.OffsetDateTime}のインスタンスを{@code java.sql.Timestamp}に変換する
+     *
+     * @param dateTime 変換対象の{@code java.time.OffsetDateTime}のインスタンス
+     * @return 変換後の{@code Timestamp}のインスタンス
+     */
+    public static Timestamp getTimestamp(final OffsetDateTime dateTime) {
+        return Timestamp.from(dateTime.atZoneSameInstant(getDateTimeConverterConfiguration().getSystemZoneId())
+                                      .toInstant());
+    }
+
+    /**
      * {@code java.time.LocalDate}のインスタンスを{@code java.util.Date}に変換する
      *
      * @param date 変換対象の{@code java.time.LocalDate}のインスタンス
@@ -178,5 +270,27 @@ public final class DateTimeConverterUtil {
     public static Date getDate(final LocalDate date) {
         return Date.from(date.atStartOfDay(getDateTimeConverterConfiguration().getSystemZoneId())
                                       .toInstant());
+    }
+
+    /**
+     * {@code java.time.OffsetDateTime}のインスタンスを{@code java.util.Date}に変換する
+     *
+     * @param dateTime 変換対象の{@code java.time.LocalDate}のインスタンス
+     * @return 変換後の{@code java.util.Date}のインスタンス
+     */
+    public static Date getDate(final OffsetDateTime dateTime) {
+        return Date.from(dateTime.atZoneSameInstant(getDateTimeConverterConfiguration().getSystemZoneId())
+                                 .toInstant());
+    }
+
+    /**
+     * {@code java.time.OffsetDateTime}のインスタンスを{@code java.sql.Date}に変換する
+     *
+     * @param dateTime 変換対象の{@code java.time.OffsetDateTime}のインスタンス
+     * @return 変換後の{@code java.sql.Date}のインスタンス
+     */
+    public static java.sql.Date getSqlDate(final OffsetDateTime dateTime) {
+        return java.sql.Date.valueOf(dateTime.atZoneSameInstant(getDateTimeConverterConfiguration().getSystemZoneId())
+                .toLocalDate());
     }
 }

--- a/src/main/java/nablarch/core/beans/converter/LocalDateTimeConverter.java
+++ b/src/main/java/nablarch/core/beans/converter/LocalDateTimeConverter.java
@@ -6,6 +6,7 @@ import nablarch.core.beans.Converter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Calendar;
@@ -68,6 +69,8 @@ public class LocalDateTimeConverter implements Converter<LocalDateTime> {
             return LocalDateTime.of(localDate, LocalTime.of(0, 0, 0));
         } else if (value instanceof LocalDateTime localDateTime) {
             return localDateTime;
+        } else if (value instanceof OffsetDateTime offsetDateTime) {
+            return DateTimeConverterUtil.getLocalDateTime(offsetDateTime);
         } else if (value instanceof java.sql.Date sqlDate) {
             return DateTimeConverterUtil.getLocalDateTimeAsSqlDate(sqlDate);
         } else if (value instanceof Date date) {

--- a/src/main/java/nablarch/core/beans/converter/OffsetDateTimeConverter.java
+++ b/src/main/java/nablarch/core/beans/converter/OffsetDateTimeConverter.java
@@ -1,8 +1,5 @@
 package nablarch.core.beans.converter;
 
-import nablarch.core.beans.ConversionException;
-import nablarch.core.beans.Converter;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -14,36 +11,35 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import nablarch.core.beans.ConversionException;
+import nablarch.core.beans.Converter;
+
 /**
- * {@code java.time.LocalDate}型への変換を行う {@link Converter} 。
+ * {@code java.time.OffsetDateTime}型への変換を行う {@link Converter} 。
  * <p>
  * 変換元の型に応じて、以下のとおり変換を行う。
  * <p>
  * <b>日付型({@code java.time.LocalDate})</b>：<br>
- * 同一日付を表す{@code java.time.LocalDate}オブジェクトを返却する。
+ * 同一日付を表す{@code java.time.OffsetDateTime}オブジェクトを返却する。
  * <p>
  * <b>日時型({@code java.time.LocalDateTime})</b>：<br>
- * 同一日付を表す{@code java.time.LocalDate}オブジェクトを返却する。
- * (時刻は切り捨て)
+ * 同一日時を表す{@code java.time.OffsetDateTime}オブジェクトを返却する。
  * <p>
  * <b>日付型</b>：<br>
- * 同一日付を表す{@code java.time.LocalDate}オブジェクトを返却する。
- * (時刻は切り捨て)
+ * 同一日付を表す{@code java.time.OffsetDateTime}オブジェクトを返却する。
  * <p>
  * <b>文字列型</b>：<br>
- * 日付文字列と同一日付を表す{@code java.time.LocalDate}オブジェクトを返却する。
- * (時刻は切り捨て)
+ * 日付文字列と同一日付を表す{@code java.time.OffsetDateTime}オブジェクトを返却する。
  * <p>
  * <b>文字列型の配列</b>：<br>
- * 要素数が1であれば、その要素を{@code java.time.LocalDate}オブジェクトに変換して返却する。
+ * 要素数が1であれば、その要素を{@code java.time.OffsetDateTime}オブジェクトに変換して返却する。
  * 要素数が1以外であれば、{@link ConversionException}を送出する。
  * <p>
  * <b>上記以外</b>：<br>
  * {@link ConversionException}を送出する。
- *
  * @author TIS
  */
-public class LocalDateConverter implements Converter<LocalDate> {
+public class OffsetDateTimeConverter implements Converter<OffsetDateTime> {
 
     /** 日付パターン */
     private final List<DateTimeFormatter> formatters;
@@ -51,50 +47,50 @@ public class LocalDateConverter implements Converter<LocalDate> {
     /**
      * デフォルトコンストラクタ
      */
-    public LocalDateConverter() {
+    public OffsetDateTimeConverter() {
         this.formatters = Collections.emptyList();
     }
 
     /**
      * 日付パターンを設定してインスタンスを構築する。
-     * 
+     *
      * @param patterns 日付パターン
      */
-    public LocalDateConverter(List<String> patterns) {
+    public OffsetDateTimeConverter(List<String> patterns) {
         this.formatters = patterns.stream()
                 .map(DateTimeFormatter::ofPattern)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public LocalDate convert(final Object value) {
+    public OffsetDateTime convert(final Object value) {
         if (value instanceof LocalDate localDate) {
-            return localDate;
+            return DateTimeConverterUtil.getOffsetDateTime(localDate);
         } else if (value instanceof LocalDateTime localDateTime) {
-            return LocalDate.from(localDateTime);
+            return DateTimeConverterUtil.getOffsetDateTime(localDateTime);
         } else if (value instanceof OffsetDateTime offsetDateTime) {
-            return DateTimeConverterUtil.getLocalDate(offsetDateTime);
+            return offsetDateTime;
         } else if (value instanceof java.sql.Date sqlDate) {
-            return DateTimeConverterUtil.getLocalDateAsSqlDate(sqlDate);
+            return DateTimeConverterUtil.getOffsetDateTimeAsSqlDate(sqlDate);
         } else if (value instanceof Date date) {
-            return DateTimeConverterUtil.getLocalDate(date);
+            return DateTimeConverterUtil.getOffsetDateTime(date);
         } else if (value instanceof Calendar cal) {
-            return DateTimeConverterUtil.getLocalDate(cal);
+            return DateTimeConverterUtil.getOffsetDateTime(cal);
         } else if (value instanceof String str) {
             return convertFromString(str);
         } else if (value instanceof String[] strArray) {
-            return SingleValueExtracter.toSingleValue(strArray, this, LocalDate.class);
+            return SingleValueExtracter.toSingleValue(strArray, this, OffsetDateTime.class);
         } else {
             throw new ConversionException(LocalDate.class, value);
         }
     }
 
-    private LocalDate convertFromString(String value) {
+    private OffsetDateTime convertFromString(String value) {
         if (!formatters.isEmpty()) {
             DateTimeParseException lastThrownException = null;
             for (DateTimeFormatter formatter : formatters) {
                 try {
-                    return LocalDate.parse(value, formatter);
+                    return OffsetDateTime.parse(value, formatter);
                 } catch (DateTimeParseException ignore) {
                     //複数のパターンを順番に試すのでParseExceptionは無視する
                     lastThrownException = ignore;
@@ -105,6 +101,6 @@ public class LocalDateConverter implements Converter<LocalDate> {
                     "the string was not formatted " + formatters + ". date = " + value + ".",
                     lastThrownException);
         }
-        return DateTimeConverterUtil.getLocalDate(value);
+        return DateTimeConverterUtil.getOffsetDateTime(value);
     }
 }

--- a/src/main/java/nablarch/core/beans/converter/SqlDateConverter.java
+++ b/src/main/java/nablarch/core/beans/converter/SqlDateConverter.java
@@ -2,6 +2,7 @@ package nablarch.core.beans.converter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -83,6 +84,8 @@ public class SqlDateConverter implements Converter<java.sql.Date> {
             return java.sql.Date.valueOf(localDate);
         } else if (value instanceof LocalDateTime localDateTime) {
             return java.sql.Date.valueOf(localDateTime.toLocalDate());
+        } else if (value instanceof OffsetDateTime offsetDateTime) {
+            return DateTimeConverterUtil.getSqlDate(offsetDateTime);
         } else {
             throw new ConversionException(java.sql.Date.class, value);
         }

--- a/src/main/java/nablarch/core/beans/converter/SqlTimestampConverter.java
+++ b/src/main/java/nablarch/core/beans/converter/SqlTimestampConverter.java
@@ -3,6 +3,7 @@ package nablarch.core.beans.converter;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -83,6 +84,8 @@ public class SqlTimestampConverter implements Converter<Timestamp> {
             return Timestamp.valueOf(localDate.atStartOfDay());
         } else if (value instanceof LocalDateTime localDateTime) {
             return Timestamp.valueOf(localDateTime);
+        } else if (value instanceof OffsetDateTime offsetDateTime) {
+            return DateTimeConverterUtil.getTimestamp(offsetDateTime);
         } else {
             throw new ConversionException(Timestamp.class, value);
         }

--- a/src/main/java/nablarch/core/beans/converter/StringConverter.java
+++ b/src/main/java/nablarch/core/beans/converter/StringConverter.java
@@ -3,6 +3,7 @@ package nablarch.core.beans.converter;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
@@ -90,6 +91,8 @@ public class StringConverter implements Mergeable<String, StringConverter> {
             return localDate.format(formatter);
         } else if (formatter != null && value instanceof LocalDateTime localDateTime) {
             return localDateTime.format(formatter);
+        } else if (formatter != null && value instanceof OffsetDateTime offsetDateTime) {
+            return offsetDateTime.format(formatter);
         }
         return StringUtil.toString(value);
     }

--- a/src/test/java/nablarch/core/beans/BasicConversionManagerTest.java
+++ b/src/test/java/nablarch/core/beans/BasicConversionManagerTest.java
@@ -6,6 +6,8 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +31,8 @@ public class BasicConversionManagerTest {
                 converters.get(LocalDate.class).convert("20180221"));
         assertEquals(LocalDateTime.of(2018, 2, 21, 0, 0),
                 converters.get(LocalDateTime.class).convert("2018-02-21T00:00:00Z"));
+        assertEquals(OffsetDateTime.of(2018, 2, 21, 0, 0, 0 , 0, ZoneOffset.UTC),
+                converters.get(OffsetDateTime.class).convert("2018-02-21T00:00:00Z"));
         assertEquals(utilDate("2018-02-21 00:00:00"),
                 converters.get(java.util.Date.class).convert("20180221"));
         assertEquals(sqlDate("2018-02-21"),
@@ -40,6 +44,9 @@ public class BasicConversionManagerTest {
                 converters.get(String.class).convert(LocalDate.of(2018, 2, 21)));
         assertEquals("2018-02-21T00:00",
                 converters.get(String.class).convert(LocalDateTime.of(2018, 2, 21, 0, 0)));
+        assertEquals("2018-02-21T00:00Z",
+                converters.get(String.class).convert(OffsetDateTime.of(2018, 2, 21, 0, 0, 0, 0, ZoneOffset.UTC)));
+
         assertEquals("Wed Feb 21 00:00:00 JST 2018",
                 converters.get(String.class).convert(utilDate("2018-02-21 00:00:00")));
         assertEquals("2018-02-21",
@@ -51,13 +58,15 @@ public class BasicConversionManagerTest {
     @Test
     public void 日付_パターン指定() {
         BasicConversionManager sut = new BasicConversionManager();
-        sut.setDatePatterns(List.of("yyyy/MM/dd", "yyyy/MM/dd HH:mm"));
+        sut.setDatePatterns(List.of("yyyy/MM/dd", "yyyy/MM/dd HH:mm", "yyyy/MM/dd HH:mm:ssZ"));
         Map<Class<?>, Converter<?>> converters = sut.getConverters();
 
         assertEquals(LocalDate.of(2018, 2, 21),
                 converters.get(LocalDate.class).convert("2018/02/21"));
         assertEquals(LocalDateTime.of(2018, 2, 21, 0, 0),
                 converters.get(LocalDateTime.class).convert("2018/02/21 00:00"));
+        assertEquals(OffsetDateTime.of(2018, 2, 21, 0, 0, 0, 0, ZoneOffset.ofHours(9)),
+                converters.get(OffsetDateTime.class).convert("2018/02/21 00:00:00+0900"));
         assertEquals(utilDate("2018-02-21 00:00:00"),
                 converters.get(java.util.Date.class).convert("2018/02/21"));
         assertEquals(sqlDate("2018-02-21"),
@@ -69,6 +78,8 @@ public class BasicConversionManagerTest {
                 converters.get(String.class).convert(LocalDate.of(2018, 2, 21)));
         assertEquals("2018/02/21",
                 converters.get(String.class).convert(LocalDateTime.of(2018, 2, 21, 0, 0)));
+        assertEquals("2018/02/21",
+                converters.get(String.class).convert(OffsetDateTime.of(2018, 2, 21, 0, 0, 0, 0, ZoneOffset.ofHours(9))));
         assertEquals("2018/02/21",
                 converters.get(String.class).convert(utilDate("2018-02-21 00:00:00")));
         assertEquals("2018/02/21",

--- a/src/test/java/nablarch/core/beans/BasicConversionManagerTest.java
+++ b/src/test/java/nablarch/core/beans/BasicConversionManagerTest.java
@@ -31,8 +31,8 @@ public class BasicConversionManagerTest {
                 converters.get(LocalDate.class).convert("20180221"));
         assertEquals(LocalDateTime.of(2018, 2, 21, 0, 0),
                 converters.get(LocalDateTime.class).convert("2018-02-21T00:00:00Z"));
-        assertEquals(OffsetDateTime.of(2018, 2, 21, 0, 0, 0 , 0, ZoneOffset.UTC),
-                converters.get(OffsetDateTime.class).convert("2018-02-21T00:00:00Z"));
+        assertEquals(OffsetDateTime.of(2018, 2, 21, 0, 0, 0 , 0, ZoneOffset.ofHours(9)),
+                converters.get(OffsetDateTime.class).convert("2018-02-21T00:00:00+09:00"));
         assertEquals(utilDate("2018-02-21 00:00:00"),
                 converters.get(java.util.Date.class).convert("20180221"));
         assertEquals(sqlDate("2018-02-21"),
@@ -44,8 +44,8 @@ public class BasicConversionManagerTest {
                 converters.get(String.class).convert(LocalDate.of(2018, 2, 21)));
         assertEquals("2018-02-21T00:00",
                 converters.get(String.class).convert(LocalDateTime.of(2018, 2, 21, 0, 0)));
-        assertEquals("2018-02-21T00:00Z",
-                converters.get(String.class).convert(OffsetDateTime.of(2018, 2, 21, 0, 0, 0, 0, ZoneOffset.UTC)));
+        assertEquals("2018-02-21T00:00+09:00",
+                converters.get(String.class).convert(OffsetDateTime.of(2018, 2, 21, 0, 0, 0, 0, ZoneOffset.ofHours(9))));
 
         assertEquals("Wed Feb 21 00:00:00 JST 2018",
                 converters.get(String.class).convert(utilDate("2018-02-21 00:00:00")));

--- a/src/test/java/nablarch/core/beans/BeanUtilTest.java
+++ b/src/test/java/nablarch/core/beans/BeanUtilTest.java
@@ -19,6 +19,8 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -1969,29 +1971,35 @@ public class BeanUtilTest {
     }
 
     /**
-     *  LocalDate型、LocalDateTime型がコピーできることを検証するケース。
+     *  LocalDate型、LocalDateTime型、OffsetDateTime型がコピーできることを検証するケース。
      */
     @Test
-    public void copyLocalDateTimeAndLocalDate() {
-        WithLocalDateTimeSrcClass src = new WithLocalDateTimeSrcClass();
+    public void copyDateAndTimeTimeAndLocalDate() {
+        WithDateAndTimeSrcClass src = new WithDateAndTimeSrcClass();
         src.setName("Taro");
         src.setDate1(LocalDate.of(2017, 6, 13));
         src.setDateTime1(LocalDateTime.of(2017, 6, 13, 11, 30, 15));
+        src.setOffsetDateTime1(OffsetDateTime.of(2017, 6, 13, 11, 30, 15, 0, ZoneOffset.ofHours(9)));
         src.setDate2(new Date(DateUtil.getDate("20170614").getTime()));
         src.setDateTime2(new Timestamp(DateUtil.getParsedDate("20170614154520", "yyyyMMddHHmmss").getTime()));
+        src.setOffsetDateTime2(new Timestamp(DateUtil.getParsedDate("20170614154520", "yyyyMMddHHmmss").getTime()));
         src.setDate3("20170615");
         src.setDateTime3("2017-06-22T10:22:30.100Z");
+        src.setOffsetDateTime3("2017-06-22T10:22:30.100Z");
         src.setDateTimes(Arrays.asList(LocalDate.of(2017, 1, 1), LocalDate.of(2017, 1, 2)));
 
-        WithLocalDateTimeDestClass dest = BeanUtil.createAndCopy(WithLocalDateTimeDestClass.class, src);
+        WithDateAndTimeDestClass dest = BeanUtil.createAndCopy(WithDateAndTimeDestClass.class, src);
 
         assertThat(dest.getName(), is("Taro"));
         assertThat(dest.getDate1(), is(LocalDate.of(2017, 6, 13)));
         assertThat(dest.getDateTime1(), is(LocalDateTime.of(2017, 6, 13, 11, 30, 15)));
+        assertThat(dest.getOffsetDateTime1(), is(OffsetDateTime.of(2017, 6, 13, 11, 30, 15, 0 , ZoneOffset.ofHours(9))));
         assertThat(dest.getDate2(), is(LocalDate.of(2017, 6, 14)));
         assertThat(dest.getDateTime2(), is(LocalDateTime.of(2017, 6, 14, 15, 45, 20)));
+        assertThat(dest.getOffsetDateTime2(), is(OffsetDateTime.of(2017, 6, 14, 15, 45, 20, 0 , ZoneOffset.ofHours(9))));
         assertThat(dest.getDate3(), is(LocalDate.of(2017, 6, 15)));
         assertThat(dest.getDateTime3(), is(LocalDateTime.of(2017, 6, 22, 10, 22, 30, 100000000)));
+        assertThat(dest.getOffsetDateTime3(), is(OffsetDateTime.of(2017, 6, 22, 10, 22, 30, 100000000 , ZoneOffset.UTC)));
         assertThat(dest.getDateTimes(), is(Arrays.asList(LocalDate.of(2017, 1, 1), LocalDate.of(2017, 1, 2))));
     }
 
@@ -2143,14 +2151,17 @@ public class BeanUtilTest {
         }
     }
 
-    private static class WithLocalDateTimeSrcClass {
+    private static class WithDateAndTimeSrcClass {
         private String name;
         private LocalDate date1;
         private LocalDateTime dateTime1;
+        private OffsetDateTime offsetDateTime1;
         private Date date2;
         private Timestamp dateTime2;
+        private Timestamp offsetDateTime2;
         private String date3;
         private String dateTime3;
+        private String offsetDateTime3;
         private List<LocalDate> dateTimes;
 
         public String getName() {
@@ -2175,6 +2186,14 @@ public class BeanUtilTest {
 
         public void setDateTime1(LocalDateTime dateTime1) {
             this.dateTime1 = dateTime1;
+        }
+
+        public OffsetDateTime getOffsetDateTime1() {
+            return offsetDateTime1;
+        }
+
+        public void setOffsetDateTime1(OffsetDateTime offsetDateTime1) {
+            this.offsetDateTime1 = offsetDateTime1;
         }
 
         public Date getDate2() {
@@ -2193,6 +2212,14 @@ public class BeanUtilTest {
             this.dateTime2 = dateTime2;
         }
 
+        public Timestamp getOffsetDateTime2() {
+            return offsetDateTime2;
+        }
+
+        public void setOffsetDateTime2(Timestamp offsetDateTime2) {
+            this.offsetDateTime2 = offsetDateTime2;
+        }
+
         public String getDate3() {
             return date3;
         }
@@ -2209,6 +2236,14 @@ public class BeanUtilTest {
             this.dateTime3 = dateTime3;
         }
 
+        public String getOffsetDateTime3() {
+            return offsetDateTime3;
+        }
+
+        public void setOffsetDateTime3(String offsetDateTime3) {
+            this.offsetDateTime3 = offsetDateTime3;
+        }
+
         public List<LocalDate> getDateTimes() {
             return dateTimes;
         }
@@ -2219,14 +2254,17 @@ public class BeanUtilTest {
     }
 
 
-    public static class WithLocalDateTimeDestClass {
+    public static class WithDateAndTimeDestClass {
         private String name;
         private LocalDate date1;
         private LocalDateTime dateTime1;
+        private OffsetDateTime offsetDateTime1;
         private LocalDate date2;
         private LocalDateTime dateTime2;
+        private OffsetDateTime offsetDateTime2;
         private LocalDate date3;
         private LocalDateTime dateTime3;
+        private OffsetDateTime offsetDateTime3;
         private List<LocalDate> dateTimes;
 
         public String getName() {
@@ -2253,6 +2291,14 @@ public class BeanUtilTest {
             this.dateTime1 = dateTime1;
         }
 
+        public OffsetDateTime getOffsetDateTime1() {
+            return offsetDateTime1;
+        }
+
+        public void setOffsetDateTime1(OffsetDateTime offsetDateTime1) {
+            this.offsetDateTime1 = offsetDateTime1;
+        }
+
         public LocalDate getDate2() {
             return date2;
         }
@@ -2267,6 +2313,14 @@ public class BeanUtilTest {
 
         public void setDateTime2(LocalDateTime dateTime2) {
             this.dateTime2 = dateTime2;
+        }
+
+        public OffsetDateTime getOffsetDateTime2() {
+            return offsetDateTime2;
+        }
+
+        public void setOffsetDateTime2(OffsetDateTime offsetDateTime2) {
+            this.offsetDateTime2 = offsetDateTime2;
         }
 
         public LocalDate getDate3() {
@@ -2285,6 +2339,14 @@ public class BeanUtilTest {
             this.dateTime3 = dateTime3;
         }
 
+        public OffsetDateTime getOffsetDateTime3() {
+            return offsetDateTime3;
+        }
+
+        public void setOffsetDateTime3(OffsetDateTime offsetDateTime3) {
+            this.offsetDateTime3 = offsetDateTime3;
+        }
+
         public List<LocalDate> getDateTimes() {
             return dateTimes;
         }
@@ -2298,4 +2360,3 @@ public class BeanUtilTest {
         return IsMapContaining.hasEntry(key, value);
     }
 }
-

--- a/src/test/java/nablarch/core/beans/ConversionUtilTest.java
+++ b/src/test/java/nablarch/core/beans/ConversionUtilTest.java
@@ -11,6 +11,8 @@ import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -249,6 +251,9 @@ public class ConversionUtilTest {
         // LocalDateTime
         assertEquals(cal.getTime(), ConversionUtil.convert(Date.class, LocalDateTime.of(2024, 2, 13, 0, 0, 0)));
 
+        // OffsetDateTime
+        assertEquals(cal.getTime(), ConversionUtil.convert(Date.class, OffsetDateTime.of(2024, 2, 13, 0, 0, 0, 0, ZoneOffset.ofHours(9))));
+
         try {
             ConversionUtil.convert(Date.class, new String[] {"20240213", "20240212"});
             fail();
@@ -296,6 +301,9 @@ public class ConversionUtilTest {
         // LocalDateTime
         assertEquals(new java.sql.Date(cal.getTimeInMillis()), ConversionUtil.convert(java.sql.Date.class, LocalDateTime.of(2024, 2, 13, 0, 0, 0)));
 
+        // OffsetDateTime
+        assertEquals(new java.sql.Date(cal.getTimeInMillis()), ConversionUtil.convert(java.sql.Date.class, OffsetDateTime.of(2024, 2, 13, 0, 0, 0, 0, ZoneOffset.UTC)));
+
         try {
             ConversionUtil.convert(java.sql.Date.class, new String[] {"20240213", "20240212"});
             fail();
@@ -342,6 +350,9 @@ public class ConversionUtilTest {
 
         // LocalDateTime
         assertEquals(new Timestamp(cal.getTimeInMillis()), ConversionUtil.convert(Timestamp.class, LocalDateTime.of(2024, 2, 13, 0, 0, 0)));
+
+        // OffsetDateTime
+        assertEquals(new Timestamp(cal.getTimeInMillis()), ConversionUtil.convert(Timestamp.class, OffsetDateTime.of(2024, 2, 13, 0, 0, 0, 0, ZoneOffset.ofHours(9))));
 
         try {
             ConversionUtil.convert(Timestamp.class, new String[] {"20240213", "20240212"});

--- a/src/test/java/nablarch/core/beans/CopyOptionsTest.java
+++ b/src/test/java/nablarch/core/beans/CopyOptionsTest.java
@@ -6,6 +6,8 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +42,7 @@ public class CopyOptionsTest {
                 .build();
         assertThat(sut.hasNamedConverter("foo", LocalDate.class), is(true));
         assertThat(sut.hasNamedConverter("foo", LocalDateTime.class), is(true));
+        assertThat(sut.hasNamedConverter("foo", OffsetDateTime.class), is(true));
         assertThat(sut.hasNamedConverter("foo", java.util.Date.class), is(true));
         assertThat(sut.hasNamedConverter("foo", java.sql.Date.class), is(true));
         assertThat(sut.hasNamedConverter("foo", Timestamp.class), is(true));
@@ -134,6 +137,9 @@ public class CopyOptionsTest {
 
         assertThat(sut.hasTypedConverter(LocalDateTime.class), is(true));
         assertThat(sut.convertByType(LocalDateTime.class, date("2018-02-14 00:00:00")), is(LocalDateTime.of(2018, 2, 14, 0, 0)));
+
+        assertThat(sut.hasTypedConverter(OffsetDateTime.class), is(true));
+        assertThat(sut.convertByType(OffsetDateTime.class, date("2018-02-14 00:00:00")), is(OffsetDateTime.of(2018, 2, 14, 0, 0, 0, 0, ZoneOffset.ofHours(9))));
 
         assertThat(sut.hasTypedConverter(java.util.Date.class), is(true));
         assertThat(sut.convertByType(java.util.Date.class, date("2018-02-14 00:00:00")), is(date("2018-02-14 00:00:00")));

--- a/src/test/java/nablarch/core/beans/converter/LocalDateConverterTest.java
+++ b/src/test/java/nablarch/core/beans/converter/LocalDateConverterTest.java
@@ -15,6 +15,8 @@ import org.junit.runner.RunWith;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 
@@ -37,6 +39,7 @@ public class LocalDateConverterTest {
                 {"20170601", LocalDate.of(2017, 6, 1)},
                 {LocalDate.of(2017, 6, 12), LocalDate.of(2017, 6, 12)},
                 {LocalDateTime.of(2017, 6, 13, 12, 30, 15), LocalDate.of(2017, 6, 13)},
+                {OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9)), LocalDate.of(2017, 6, 13)},
                 {DateUtil.getParsedDate("20170621000000000", "yyyyMMddHHmmssSSS"), LocalDate.of(2017, 6, 21)},
                 {DateUtil.getParsedDate("20170622235011300", "yyyyMMddHHmmssSSS"), LocalDate.of(2017, 6, 22)},
                 {newSqlDate("19490402000000", "yyyyMMddHHmmss"), LocalDate.of(1949, 4, 2)}

--- a/src/test/java/nablarch/core/beans/converter/LocalDateConverterTest.java
+++ b/src/test/java/nablarch/core/beans/converter/LocalDateConverterTest.java
@@ -39,7 +39,10 @@ public class LocalDateConverterTest {
                 {"20170601", LocalDate.of(2017, 6, 1)},
                 {LocalDate.of(2017, 6, 12), LocalDate.of(2017, 6, 12)},
                 {LocalDateTime.of(2017, 6, 13, 12, 30, 15), LocalDate.of(2017, 6, 13)},
-                {OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9)), LocalDate.of(2017, 6, 13)},
+                // デフォルトタイムゾーンのオフセットに読み替えられる（デフォルトはAsia/Tokyo）
+                {OffsetDateTime.of(2017, 6, 13, 20, 30, 15, 0, ZoneOffset.ofHours(9)), LocalDate.of(2017, 6, 13)},
+                {OffsetDateTime.of(2017, 6, 13, 20, 30, 15, 0, ZoneOffset.UTC), LocalDate.of(2017, 6, 14)},
+                {OffsetDateTime.of(2017, 6, 13, 20, 30, 15, 0, ZoneOffset.ofHours(3)), LocalDate.of(2017, 6, 14)},
                 {DateUtil.getParsedDate("20170621000000000", "yyyyMMddHHmmssSSS"), LocalDate.of(2017, 6, 21)},
                 {DateUtil.getParsedDate("20170622235011300", "yyyyMMddHHmmssSSS"), LocalDate.of(2017, 6, 22)},
                 {newSqlDate("19490402000000", "yyyyMMddHHmmss"), LocalDate.of(1949, 4, 2)}

--- a/src/test/java/nablarch/core/beans/converter/LocalDateTimeConverterTest.java
+++ b/src/test/java/nablarch/core/beans/converter/LocalDateTimeConverterTest.java
@@ -39,7 +39,10 @@ public class LocalDateTimeConverterTest {
                 {"2017-06-01T10:22:30.100Z", LocalDateTime.of(2017, 6, 1, 10, 22, 30, 100000000)},
                 {LocalDate.of(2017, 6, 12), LocalDateTime.of(2017, 6, 12, 0, 0, 0)},
                 {LocalDateTime.of(2017, 6, 13, 12, 30, 15), LocalDateTime.of(2017, 6, 13, 12, 30, 15)},
-                {OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9)), LocalDateTime.of(2017, 6, 13, 12, 30, 15)},
+                // デフォルトタイムゾーンのオフセットに読み替えられる（デフォルトはAsia/Tokyo）
+                {OffsetDateTime.of(2017, 6, 13, 5, 30, 15, 0, ZoneOffset.ofHours(9)), LocalDateTime.of(2017, 6, 13, 5, 30, 15)},
+                {OffsetDateTime.of(2017, 6, 13, 5, 30, 15, 0, ZoneOffset.UTC), LocalDateTime.of(2017, 6, 13, 14, 30, 15)},
+                {OffsetDateTime.of(2017, 6, 13, 5, 30, 15, 0, ZoneOffset.ofHours(3)), LocalDateTime.of(2017, 6, 13, 11, 30, 15)},
                 {DateUtil.getParsedDate("20170621030530500", "yyyyMMddHHmmssSSS"), LocalDateTime.of(2017, 6, 21, 3, 5, 30, 500000000)},
                 {DateUtil.getParsedDate("20170622235011300", "yyyyMMddHHmmssSSS"), LocalDateTime.of(2017, 6, 22, 23, 50, 11, 300000000)},
                 {newSqlDate("20170623123015", "yyyyMMddHHmmss"), LocalDateTime.of(2017, 6, 23, 0, 0, 0)}

--- a/src/test/java/nablarch/core/beans/converter/LocalDateTimeConverterTest.java
+++ b/src/test/java/nablarch/core/beans/converter/LocalDateTimeConverterTest.java
@@ -15,6 +15,8 @@ import org.junit.runner.RunWith;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 
@@ -37,6 +39,7 @@ public class LocalDateTimeConverterTest {
                 {"2017-06-01T10:22:30.100Z", LocalDateTime.of(2017, 6, 1, 10, 22, 30, 100000000)},
                 {LocalDate.of(2017, 6, 12), LocalDateTime.of(2017, 6, 12, 0, 0, 0)},
                 {LocalDateTime.of(2017, 6, 13, 12, 30, 15), LocalDateTime.of(2017, 6, 13, 12, 30, 15)},
+                {OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9)), LocalDateTime.of(2017, 6, 13, 12, 30, 15)},
                 {DateUtil.getParsedDate("20170621030530500", "yyyyMMddHHmmssSSS"), LocalDateTime.of(2017, 6, 21, 3, 5, 30, 500000000)},
                 {DateUtil.getParsedDate("20170622235011300", "yyyyMMddHHmmssSSS"), LocalDateTime.of(2017, 6, 22, 23, 50, 11, 300000000)},
                 {newSqlDate("20170623123015", "yyyyMMddHHmmss"), LocalDateTime.of(2017, 6, 23, 0, 0, 0)}

--- a/src/test/java/nablarch/core/beans/converter/OffsetDateTimeConverterTest.java
+++ b/src/test/java/nablarch/core/beans/converter/OffsetDateTimeConverterTest.java
@@ -1,0 +1,129 @@
+package nablarch.core.beans.converter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+
+import nablarch.core.beans.ConversionException;
+import nablarch.core.beans.Converter;
+import nablarch.core.util.DateUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+/**
+ * {@link OffsetDateTime}のテスト
+ */
+@RunWith(Enclosed.class)
+public class OffsetDateTimeConverterTest {
+    static java.sql.Date newSqlDate(String date, String pattern) {
+        return new java.sql.Date(DateUtil.getParsedDate(date, pattern).getTime());
+    }
+
+    static Calendar newCalendar(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        return calendar;
+    }
+
+    @RunWith(Theories.class)
+    public static class OffsetDateTimeConvertSuccessTest {
+        @DataPoints
+        public static Object[][] params = {
+                {"2017-06-01T10:22:30.100Z", OffsetDateTime.of(2017, 6, 1, 10, 22, 30, 100000000, ZoneOffset.UTC)},
+                {new String[]{"2017-06-01T10:22:30.100Z"}, OffsetDateTime.of(2017, 6, 1, 10, 22, 30, 100000000, ZoneOffset.UTC)},
+                {LocalDate.of(2017, 6, 12), OffsetDateTime.of(2017, 6, 12, 0, 0, 0, 0, ZoneOffset.ofHours(9))},
+                {LocalDateTime.of(2017, 6, 13, 12, 30, 15), OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9))},
+                {OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9)), OffsetDateTime.of(2017, 6, 13, 12, 30, 15, 0, ZoneOffset.ofHours(9))},
+                {DateUtil.getParsedDate("20170621030530500", "yyyyMMddHHmmssSSS"), OffsetDateTime.of(2017, 6, 21, 3, 5, 30, 500000000, ZoneOffset.ofHours(9))},
+                {newCalendar(DateUtil.getParsedDate("20170622235011300", "yyyyMMddHHmmssSSS")), OffsetDateTime.of(2017, 6, 22, 23, 50, 11, 300000000, ZoneOffset.ofHours(9))},
+                {newSqlDate("20170623123015", "yyyyMMddHHmmss"), OffsetDateTime.of(2017, 6, 23, 0, 0, 0, 0, ZoneOffset.ofHours(9))}
+        };
+
+        @Theory
+        public void test(Object[] testParams) {
+            Object value = testParams[0];
+            OffsetDateTime expected = (OffsetDateTime) testParams[1];
+
+            Converter<OffsetDateTime> converter = new OffsetDateTimeConverter();
+            assertThat(converter.convert(value), is(expected));
+        }
+    }
+
+    @RunWith(Theories.class)
+    public static class DateConvertParseFailTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        @DataPoints
+        public static Object[] params = {"abc", "20170625"};
+
+        @Theory
+        public void test(Object value) {
+            expectedException.expect(DateTimeParseException.class);
+            Converter<OffsetDateTime> converter = new OffsetDateTimeConverter();
+            converter.convert(value);
+        }
+    }
+
+    @RunWith(Theories.class)
+    public static class DateConvertUnsupportedTypeTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        @DataPoints
+        public static Object[] params = {10};
+
+        @Theory
+        public void test(Object value) {
+            expectedException.expect(ConversionException.class);
+            Converter<OffsetDateTime> converter = new OffsetDateTimeConverter();
+            converter.convert(value);
+        }
+    }
+
+    /**
+     * 日付パターンのテスト。
+     */
+    public static class PatternTest {
+
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        @Test
+        public void デフォルト() {
+            final OffsetDateTimeConverter sut = new OffsetDateTimeConverter();
+            assertEquals(OffsetDateTime.of(2018, 2, 21, 12, 34, 0, 0, ZoneOffset.UTC), sut.convert("2018-02-21T12:34:00Z"));
+        }
+
+        @Test
+        public void パターン指定() {
+            final OffsetDateTimeConverter sut = new OffsetDateTimeConverter(
+                    Arrays.asList("yyyy/MM/dd HH:mmZ", "yyyy.MM.dd HHmmZ"));
+            assertEquals(OffsetDateTime.of(2018, 2, 21, 12, 34, 0, 0, ZoneOffset.ofHours(9)), sut.convert("2018/02/21 12:34+0900"));
+            assertEquals(OffsetDateTime.of(2018, 2, 21, 12, 34, 0, 0, ZoneOffset.ofHours(9)), sut.convert("2018.02.21 1234+0900"));
+        }
+
+        @Test
+        public void 変換失敗() {
+            expectedException.expect(IllegalArgumentException.class);
+            final OffsetDateTimeConverter sut = new OffsetDateTimeConverter(
+                    Arrays.asList("yyyy/MM/dd HH:mm", "yyyy.MM.dd HHmm"));
+            sut.convert("201802211234");
+        }
+    }
+}

--- a/src/test/java/nablarch/core/beans/converter/StringConverterTest.java
+++ b/src/test/java/nablarch/core/beans/converter/StringConverterTest.java
@@ -7,6 +7,8 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 
 import nablarch.core.beans.ConversionException;
@@ -98,6 +100,16 @@ public class StringConverterTest {
     @Test
     public void LocalDateTimeWithPattern() {
         assertThat(new StringConverter("yyyy/MM/dd", null).convert(LocalDateTime.of(2018, 2, 19, 15, 10)), is("2018/02/19"));
+    }
+
+    @Test
+    public void OffsetDateTimeWithoutPattern() {
+        assertThat(sut.convert(OffsetDateTime.of(2018, 2, 19, 15, 10, 18, 0, ZoneOffset.ofHours(9))), is("2018-02-19T15:10:18+09:00"));
+    }
+
+    @Test
+    public void OffsetDateTimeWithPattern() {
+        assertThat(new StringConverter("yyyy/MM/dd HH:mm:ssZ", null).convert(OffsetDateTime.of(2018, 2, 19, 15, 10, 0, 0, ZoneOffset.UTC)), is("2018/02/19 15:10:00+0000"));
     }
 
     @Test

--- a/src/test/java/nablarch/core/beans/sample/CustomConversionManager.java
+++ b/src/test/java/nablarch/core/beans/sample/CustomConversionManager.java
@@ -5,6 +5,7 @@ import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import nablarch.core.beans.converter.LocalDateConverter;
 import nablarch.core.beans.converter.LocalDateTimeConverter;
 import nablarch.core.beans.converter.LongConverter;
 import nablarch.core.beans.converter.ObjectArrayConverter;
+import nablarch.core.beans.converter.OffsetDateTimeConverter;
 import nablarch.core.beans.converter.ShortConverter;
 import nablarch.core.beans.converter.SqlDateConverter;
 import nablarch.core.beans.converter.SqlTimestampConverter;
@@ -58,6 +60,7 @@ public class CustomConversionManager implements ConversionManager {
         converterMap.put(Timestamp.class, new SqlTimestampConverter());
         converterMap.put(LocalDate.class, new LocalDateConverter());
         converterMap.put(LocalDateTime.class, new LocalDateTimeConverter());
+        converterMap.put(OffsetDateTime.class, new OffsetDateTimeConverter());
 
         // PJ固有のコンバータ
         converterMap.put(BigInteger.class, new CustomConverter());


### PR DESCRIPTION
# 概要

関連PR： https://github.com/nablarch/nablarch-jaxrs-adaptor/pull/48

`OffsetDateTime`を扱う`Converter`および`DateTimeConverterConfiguration`への変換メソッドを追加。

- 変換方針
  - `java.util.*`、`java.sql.*`の日付クラスからの変換の時には、同じタイムゾーンに合わせるようにして変換
  - オフセットが日本時間以外の場合に`OffsetDateTime#toLocalDatetime`などを行うとローカル日時の部分だけが切り取られるため
- 後方互換性について
  - `DateTimeConverterConfiguration`に`OffsetDateTime`用の`DateTimeFormatter`を返すデフォルトメソッドを追加（`DateTimeConverterConfiguration`は`@Published(tag = "architect")`であり、他の`DateTimeFormatter`は`LocalDateTime`向けのものであるため）

タイムゾーン変換のうえのローカル日時への変換の例。

```java
        OffsetDateTime localZoneDateTime = OffsetDateTime.of(2024, 11, 14, 13, 15, 30, 0, ZoneOffset.ofHours(9));
        OffsetDateTime utcDateTime = OffsetDateTime.of(2024, 11, 14, 13, 15, 30, 0, ZoneOffset.UTC);

        System.out.printf("At Zone Same Instant:%n");
        System.out.printf("  Asia/Tokyo -> Asia/Tokyo: %s -> %s%n", localZoneDateTime, localZoneDateTime.atZoneSameInstant(ZoneId.of("Asia/Tokyo")).toLocalDateTime());
        System.out.printf("  Asia/Tokyo -> UTC       : %s -> %s%n", localZoneDateTime, localZoneDateTime.atZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime());
        System.out.printf("  UTC -> Asia/Tokyo       : %s      -> %s%n", utcDateTime, utcDateTime.atZoneSameInstant(ZoneId.of("Asia/Tokyo")).toLocalDateTime());
        System.out.printf("  UTC -> UTC              : %s      -> %s%n", utcDateTime, utcDateTime.atZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime());

        System.out.println();

        System.out.printf("to LocalDateTime:%n");
        System.out.printf("  Asia/Tokyo -> LocalDateTime: %s -> %s%n", localZoneDateTime, localZoneDateTime.toLocalDateTime());
        System.out.printf("  UTC -> LocalDateTime       : %s      -> %s%n", utcDateTime, utcDateTime.toLocalDateTime());
```

実行結果。

```shell
At Zone Same Instant:
  Asia/Tokyo -> Asia/Tokyo: 2024-11-14T13:15:30+09:00 -> 2024-11-14T13:15:30
  Asia/Tokyo -> UTC       : 2024-11-14T13:15:30+09:00 -> 2024-11-14T04:15:30
  UTC -> Asia/Tokyo       : 2024-11-14T13:15:30Z      -> 2024-11-14T22:15:30
  UTC -> UTC              : 2024-11-14T13:15:30Z      -> 2024-11-14T13:15:30

to LocalDateTime:
  Asia/Tokyo -> LocalDateTime: 2024-11-14T13:15:30+09:00 -> 2024-11-14T13:15:30
  UTC -> LocalDateTime       : 2024-11-14T13:15:30Z      -> 2024-11-14T13:15:30
```

# ドキュメントの変更

`BeanUtil`のドキュメントには`LocalDateTime`などの型に対する言及はない。

https://nablarch.github.io/docs/6u2/doc/application_framework/application_framework/libraries/bean_util.html#utility-conversion

JSR-310アダプタについては対応型を明記しているため、追加と新しい`nablarch-core-beans`を参照するためモジュールのバージョンインクリメント（リリース）が必要。

https://nablarch.github.io/docs/6u2/doc/application_framework/adaptors/jsr310_adaptor.html