### PR TITLE
コメント修正、BeansExceptionでネストしたプロパティ処理の失敗の見せ方の見直し

### DIFF
--- a/src/main/java/nablarch/core/beans/BeanUtil.java
+++ b/src/main/java/nablarch/core/beans/BeanUtil.java
@@ -783,7 +783,8 @@ public final class BeanUtil {
         try {
             copyMapInner(bean, srcMap, copyOptions, null);
         } catch (BeansException bex) {
-            if (bex.hasNotBeenHandled()) {
+            if (bex.isNodePropertyOperationFailure()) {
+                // ネストしたプロパティ操作のログは他の箇所で出力済みなので、ここでは単一のプロパティ操作の失敗のみを扱う
                 LOGGER.logDebug("An error occurred while writing");
             }
         }
@@ -806,49 +807,60 @@ public final class BeanUtil {
             throw new IllegalArgumentException("The target bean must not be a record.");
         }
 
-        // ノードとネストでは処理内容が違うので分けて処理する。
-        // ネストの場合は同一のルートでまとめて処理をする。
-        Map<String, Map<String, Object>> nestMap = new HashMap<>();
-        boolean allError = true;
-        String parentProperty = parentExpression == null ? "" : parentExpression.getRawKey();
+        // ネストしたプロパティはmapのキー単位ではなくグルーピングして一括して操作して処理効率を向上させるため、
+        // 1度中間Mapに格納する
+        Map<String, Map<String, Object>> nestedMap = new HashMap<>();
+        // このメソッドで扱うプロパティはネストしたものを集約したものになるため、操作に成功したプロパティが
+        // ひとつもなかった場合はプロパティ全体の操作が失敗したと判定させる
+        boolean anyPropertyOperationSucceeded = false;
+
         for (Map.Entry<String, ?> entry : map.entrySet()) {
 
             try {
                 PropertyExpression expression = new PropertyExpression(entry.getKey());
                 if (expression.isNode()) {
+                    // 単一のプロパティの場合はそのままコピー操作へディスパッチする
                     Map<String, Object> nodeMap = new HashMap<>();
                     nodeMap.put(entry.getKey(), entry.getValue());
                     setNodeProperty(bean, expression, nodeMap);
                 } else {
-                    // 同一のルートを持つプロパティをグルーピング
-                    nestMap.computeIfAbsent(expression.getRoot(), key -> new HashMap<>())
+                    // 同一のルートを持つプロパティの場合はグルーピングして後続で一括処理する
+                    // 例）"a.b.c"と"a.b.d"は"a"をキーとしてグルーピングされる
+                    //    "a"に紐づく値は、"a.b.c"と"a.b.d"それぞれをキーとして持つMapとなる
+                    nestedMap.computeIfAbsent(expression.getRoot(), key -> new HashMap<>())
                             .put(entry.getKey(), entry.getValue());
                 }
-                allError = false;
+
+                anyPropertyOperationSucceeded = true;
             } catch (BeansException bex) {
-                String propertyName = StringUtil.isNullOrEmpty(parentProperty) ? entry.getKey()
-                        : parentProperty + "." + entry.getKey();
+                String propertyName = parentExpression != null ?
+                        parentExpression.getRawKey() + "." + entry.getKey() : entry.getKey();
                 LOGGER.logDebug("An error occurred while writing to the property :" + propertyName);
             }
         }
 
-        for (Map.Entry<String, Map<String, Object>> nestEntry : nestMap.entrySet()) {
+        // ネストしたプロパティはグルーピングしたキーごとに一括して処理を行う
+        for (Map.Entry<String, Map<String, Object>> nestedEntry : nestedMap.entrySet()) {
+            PropertyExpression expression = parentExpression != null ?
+                    new PropertyExpression(parentExpression.getRawKey(), nestedEntry.getKey()) : new PropertyExpression(nestedEntry.getKey());
+
             try {
-                setNestedProperty(bean,
-                        new PropertyExpression(parentProperty, nestEntry.getKey()), nestEntry.getValue(), copyOptions);
-                allError = false;
+                setNestedProperty(bean, expression, nestedEntry.getValue(), copyOptions);
+                anyPropertyOperationSucceeded = true;
             } catch (BeansException bex) {
-                if (bex.hasNotBeenHandled()) {
-                    String propertyName = StringUtil.isNullOrEmpty(parentProperty) ? nestEntry.getKey()
-                            : parentProperty + "." + nestEntry.getKey();
+                if (bex.isNodePropertyOperationFailure()) {
+                    // ネストしたプロパティ操作のログは他の箇所で出力済みなので、ここでは単一のプロパティ操作の失敗のみを扱う
+                    String propertyName = parentExpression != null ?
+                            parentExpression.getRawKey() + "." + nestedEntry.getKey() : nestedEntry.getKey();
                     LOGGER.logDebug("An error occurred while writing to the property :" + propertyName);
                 }
             }
         }
-        // ループ内のすべての処理でエラーが発生した場合は例外を送出する。
-        // 理由は、この場合に呼び出し元で次の処理に進ませないようにするため。
-        if (allError) {
-            throw new BeansException(false);
+
+        if (!anyPropertyOperationSucceeded) {
+            // ひとつもプロパティの操作が成功しなかった場合は、プロパティ全体の操作が失敗したと判定する
+            // 呼び出し元が操作に成功したプロパティを扱う処理になっている場合は、この例外で処理をスキップさせる
+            throw BeansException.createNestedPropertiesOperationFailure();
         }
     }
 
@@ -1009,10 +1021,10 @@ public final class BeanUtil {
         final CopyOptions mergedCopyOptions = copyOptions
                 .merge(CopyOptions.fromAnnotation(beanClass));
 
-        Map<String, Map<String, Object>> nestMap = new HashMap<>();
+        // ネストしたプロパティはmapのキー単位ではなくグルーピングして一括して操作して処理効率を向上させるため、
+        // 1度中間Mapに格納する
+        Map<String, Map<String, Object>> nestedMap = new HashMap<>();
 
-        // ノードとネストでは処理内容が違うので分けて処理する。
-        // ネストの場合は同一のルートでまとめて処理をする。
         for (Map.Entry<String, ?> entry : map.entrySet()) {
             String propertyName = entry.getKey();
             Object propertyValue = entry.getValue();
@@ -1037,8 +1049,10 @@ public final class BeanUtil {
                         }
                     }
                 } else {
-                    // 同一のルートを持つプロパティをグルーピング
-                    nestMap.computeIfAbsent(expression.getRoot(), key -> new HashMap<>())
+                    // 同一のルートを持つプロパティの場合はグルーピングして後続で一括処理する
+                    // 例）"a.b.c"と"a.b.d"は"a"をキーとしてグルーピングされる
+                    //    "a"に紐づく値は、"a.b.c"と"a.b.d"それぞれをキーとして持つMapとなる
+                    nestedMap.computeIfAbsent(expression.getRoot(), key -> new HashMap<>())
                             .put(entry.getKey(), entry.getValue());
                 }
             } catch (BeansException bex) {
@@ -1046,23 +1060,24 @@ public final class BeanUtil {
             }
         }
 
-        for (Map.Entry<String, Map<String, Object>> nestEntry : nestMap.entrySet()) {
-            PropertyExpression expression = new PropertyExpression(nestEntry.getKey());
+        // ネストしたプロパティはグルーピングしたキーごとに一括して処理を行う
+        for (Map.Entry<String, Map<String, Object>> nestedEntry : nestedMap.entrySet()) {
+            PropertyExpression expression = new PropertyExpression(nestedEntry.getKey());
             try {
                 if (expression.isListOrArray()) {
                     Class<?> propertyType = getPropertyType(beanClass, expression.getListPropertyName());
                     if (propertyType.isArray()) {
-                        setNestedArrayPropertyToMap(beanClass, expression, propertyMap, nestEntry.getValue(), copyOptions);
+                        setNestedArrayPropertyToMap(beanClass, expression, propertyMap, nestedEntry.getValue(), copyOptions);
                     } else if (List.class.isAssignableFrom(propertyType)) {
-                        setNestedListPropertyToMap(beanClass, expression, propertyMap, nestEntry.getValue(), copyOptions);
+                        setNestedListPropertyToMap(beanClass, expression, propertyMap, nestedEntry.getValue(), copyOptions);
                     } else {
                         throw new BeansException("property type must be List or Array.");
                     }
                 } else {
-                    setNestedObjectPropertyToMap(beanClass, expression, propertyMap, nestEntry.getValue(), copyOptions);
+                    setNestedObjectPropertyToMap(beanClass, expression, propertyMap, nestedEntry.getValue(), copyOptions);
                 }
             } catch (BeansException bex) {
-                LOGGER.logDebug("An error occurred while copying the property :" + nestEntry.getKey() + " original exception: " + bex);
+                LOGGER.logDebug("An error occurred while copying the property :" + nestedEntry.getKey() + " original exception: " + bex);
             }
         }
 

--- a/src/main/java/nablarch/core/beans/BeanUtil.java
+++ b/src/main/java/nablarch/core/beans/BeanUtil.java
@@ -810,8 +810,8 @@ public final class BeanUtil {
         // ネストしたプロパティはmapのキー単位ではなくグルーピングして一括して操作して処理効率を向上させるため、
         // 1度中間Mapに格納する
         Map<String, Map<String, Object>> nestedMap = new HashMap<>();
-        // このメソッドで扱うプロパティはネストしたものを集約したものになるため、操作に成功したプロパティが
-        // ひとつもなかった場合はプロパティ全体の操作が失敗したと判定させる
+        // 操作に成功したプロパティがひとつもなかった場合はプロパティ全体の操作が失敗したと判定させる
+        // （ネストしている場合は複数プロパティを扱うため）
         boolean anyPropertyOperationSucceeded = false;
 
         for (Map.Entry<String, ?> entry : map.entrySet()) {

--- a/src/main/java/nablarch/core/beans/BeansException.java
+++ b/src/main/java/nablarch/core/beans/BeansException.java
@@ -15,9 +15,9 @@ public class BeansException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 未処理かどうか
+     * 例外の原因が、ネストした（グルーピングされた）プロパティの一括操作に失敗したことを表す
      */
-    private boolean notHandled;
+    private boolean nestedPropertyOperationFailure = false;
 
     /**
      * コンストラクタ。
@@ -26,15 +26,6 @@ public class BeansException extends RuntimeException {
      */
     public BeansException(String message) {
         super(message);
-    }
-
-    /**
-     * コンストラクタ。
-     *
-     * @param notHandled 未処理かどうか
-     */
-    public BeansException(boolean notHandled) {
-        this.notHandled = notHandled;
     }
 
     /**
@@ -57,10 +48,38 @@ public class BeansException extends RuntimeException {
     }
 
     /**
-     * 例外がすでに処理済みかどうか
-     * @return 未処理の場合はtrue/処理済みの場合はfalse
+     * ネストした（グルーピングされた）プロパティ操作に失敗したことを表すインスタンスを生成する
+     *
+     * @param nestedPropertyOperationFailure ネストした（グルーピングされた）プロパティ操作に失敗したかどうか
      */
-    public boolean hasNotBeenHandled() {
-        return notHandled;
+    private BeansException(boolean nestedPropertyOperationFailure) {
+        this.nestedPropertyOperationFailure = nestedPropertyOperationFailure;
+    }
+
+    /**
+     * ネストした（グルーピングされた）プロパティ操作に失敗したことを表すインスタンスを生成する
+     *
+     * @return ネストした（グルーピングされた）プロパティ操作に失敗したことを表すインスタンス
+     */
+    static BeansException createNestedPropertiesOperationFailure() {
+        return new BeansException(true);
+    }
+
+    /**
+     * この例外の原因がネストした（グルーピングされた）プロパティ操作に失敗したものである場合{@code true}を返す
+     *
+     * @return この例外の原因がネストした（グルーピングされた）プロパティ操作に失敗したものである場合{@code true}
+     */
+    boolean isNestedPropertyOperationFailure() {
+        return nestedPropertyOperationFailure;
+    }
+
+    /**
+     * この例外の原因がシンプルなプロパティ操作に失敗したものである場合{@code true}を返す
+     *
+     * @return この例外の原因がシンプルなプロパティ操作に失敗したものである場合{@code true}
+     */
+    boolean isNodePropertyOperationFailure() {
+        return !isNestedPropertyOperationFailure();
     }
 }

--- a/src/main/java/nablarch/core/beans/BeansException.java
+++ b/src/main/java/nablarch/core/beans/BeansException.java
@@ -15,9 +15,9 @@ public class BeansException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 例外の原因が、ネストした（グルーピングされた）プロパティの一括操作に失敗したことを表す
+     * Beanに対する{@code Map}からのあるプロパティのコピー操作に失敗したことを表す
      */
-    private boolean nestedPropertyOperationFailure = false;
+    private boolean copyPropertyFromMapInternalError = false;
 
     /**
      * コンストラクタ。
@@ -47,39 +47,24 @@ public class BeansException extends RuntimeException {
         super(msg, t);
     }
 
+
     /**
-     * ネストした（グルーピングされた）プロパティ操作に失敗したことを表すインスタンスを生成する
+     * Beanに対する{@code Map}からのあるプロパティのコピー操作に失敗したことを表すインスタンスを生成する
      *
-     * @param nestedPropertyOperationFailure ネストした（グルーピングされた）プロパティ操作に失敗したかどうか
+     * @return Beanに対する{@code Map}からのあるプロパティのコピー操作に失敗したことを表すインスタンス
      */
-    private BeansException(boolean nestedPropertyOperationFailure) {
-        this.nestedPropertyOperationFailure = nestedPropertyOperationFailure;
+    static BeansException createCopyPropertyFromMapInternalError() {
+        BeansException e = new BeansException("An error occurred while copying a property from the map");
+        e.copyPropertyFromMapInternalError = true;
+        return e;
     }
 
     /**
-     * ネストした（グルーピングされた）プロパティ操作に失敗したことを表すインスタンスを生成する
+     * この例外の原因がBeanに対する{@code Map}からのあるプロパティのコピー操作に失敗したことを表すものの場合{@code true}を返す
      *
-     * @return ネストした（グルーピングされた）プロパティ操作に失敗したことを表すインスタンス
+     * @return の例外の原因がBeanに対する{@code Map}からのあるプロパティのコピー操作に失敗したことを表すものの場合{@code true}
      */
-    static BeansException createNestedPropertiesOperationFailure() {
-        return new BeansException(true);
-    }
-
-    /**
-     * この例外の原因がネストした（グルーピングされた）プロパティ操作に失敗したものである場合{@code true}を返す
-     *
-     * @return この例外の原因がネストした（グルーピングされた）プロパティ操作に失敗したものである場合{@code true}
-     */
-    boolean isNestedPropertyOperationFailure() {
-        return nestedPropertyOperationFailure;
-    }
-
-    /**
-     * この例外の原因がシンプルなプロパティ操作に失敗したものである場合{@code true}を返す
-     *
-     * @return この例外の原因がシンプルなプロパティ操作に失敗したものである場合{@code true}
-     */
-    boolean isNodePropertyOperationFailure() {
-        return !isNestedPropertyOperationFailure();
+    boolean isNotCopyPropertyFromMapInternalError() {
+        return !copyPropertyFromMapInternalError;
     }
 }

--- a/src/main/java/nablarch/core/beans/PropertyExpression.java
+++ b/src/main/java/nablarch/core/beans/PropertyExpression.java
@@ -69,8 +69,8 @@ class PropertyExpression {
      * @param expression ネストしたプロパティの文字列表現（ドット区切り）
      */
     PropertyExpression(String parentExpression, String expression) {
-        if (Objects.isNull(parentExpression) || StringUtil.isNullOrEmpty(expression)) {
-            throw new IllegalArgumentException("parentExpression is null or expression is null or blank.");
+        if (StringUtil.isNullOrEmpty(parentExpression) || StringUtil.isNullOrEmpty(expression)) {
+            throw new IllegalArgumentException("parentExpression or expression is null or blank.");
         }
         this.nestedProperties = new LinkedList<>(Arrays.asList(expression.split("\\.")));
         this.listPropertyInfo = createListPropertyInfo();


### PR DESCRIPTION
#40 に対する、以下の内容の修正版。

- ネストしたプロパティを分解、後続処理する際のコメントを追加
- `BeansException`にネストしたプロパティを関する処理に失敗したかどうかを判別できる名前にリネーム
  - これらは`BeanUtil`の内部的な使用用途なので`public`ではなく`private`またはパッケージスコープとして利用者には非公開化
- `BeanUtils#copyMapInner`メソッドで、ログ出力を主目的にしていた変数の最小化
- `nest` → `nested`になっていなかった部分の修正